### PR TITLE
Add missing break case for remove_runner

### DIFF
--- a/caf_solution/add-ons/gha_runner/scripts/remove_runner/remove_runner.go
+++ b/caf_solution/add-ons/gha_runner/scripts/remove_runner/remove_runner.go
@@ -39,7 +39,7 @@ func GetRunnersToRemove(client *github.Client, config Config) (map[int64]*github
 				}
 			}
 		}
-		if resp.NextPage == 0 {
+		if resp.NextPage == 0 || len(runnersToRemove) == config.numRunners {
 			break
 		}
 		opt.Page = resp.NextPage


### PR DESCRIPTION
The helper script is designed to fetch lists of runners from the GH API
page by page until it finds info on all runners it needs. We were
missing a break condition for this which would result in all pages been
fetched regardless (not an issue right now for small amounts of runners
but could be in the future!)