### PR TITLE
Add new var: app_config_entries

### DIFF
--- a/caf_solution/local.database.tf
+++ b/caf_solution/local.database.tf
@@ -3,6 +3,7 @@ locals {
     var.database,
     {
       app_config                         = var.app_config
+      app_config_entries                 = var.app_config_entries
       azurerm_redis_caches               = var.azurerm_redis_caches
       cosmos_dbs                         = var.cosmos_dbs
       cosmosdb_sql_databases             = var.cosmosdb_sql_databases

--- a/caf_solution/variables.database.tf
+++ b/caf_solution/variables.database.tf
@@ -1,6 +1,10 @@
 variable "app_config" {
   default = {}
 }
+variable "app_config_entries" {
+  description = "Map of objects describing kv entries to an app config."
+  default     = {}
+}
 variable "azurerm_redis_caches" {
   default = {}
 }


### PR DESCRIPTION
This allows use of the new related functionality in
terraform-azurerm-caf, which allows for adding entries to an azure
appconfig instance in a more flexible way.

See, https://github.com/aztfmod/terraform-azurerm-caf/pull/1221