### PR TITLE
Add appconfig functionality to gha_runner

### DIFF
--- a/caf_solution/add-ons/gha_runner/locals.remote_tfstates.tf
+++ b/caf_solution/add-ons/gha_runner/locals.remote_tfstates.tf
@@ -64,6 +64,16 @@ locals {
     vnets = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].vnets, {}))
     }
+
+    app_config = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].app_config,
+      {}))
+    }
+
+    azure_container_registries = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azure_container_registries,
+      {}))
+    }
   }
 }
 

--- a/caf_solution/add-ons/gha_runner/locals.tf
+++ b/caf_solution/add-ons/gha_runner/locals.tf
@@ -7,6 +7,13 @@ locals {
     }
   )
 
+  database = merge(
+    var.database,
+    {
+      app_config_entries = var.app_config_entries
+    }
+  )
+
   security = merge(
     var.security,
     {

--- a/caf_solution/add-ons/gha_runner/main.tf
+++ b/caf_solution/add-ons/gha_runner/main.tf
@@ -25,6 +25,14 @@ provider "azurerm" {
   }
 }
 
+provider "azurerm" {
+  alias                      = "vhub"
+  skip_provider_registration = true
+  features {}
+  #subscription_id = local.connectivity_subscription_id
+  #tenant_id       = local.connectivity_tenant_id
+}
+
 data "azurerm_client_config" "current" {}
 
 locals {

--- a/caf_solution/add-ons/gha_runner/solution.tf
+++ b/caf_solution/add-ons/gha_runner/solution.tf
@@ -1,9 +1,16 @@
 module "caf" {
-  source  = "aztfmod/caf/azurerm"
-  version = "~>5.4.2"
+  #source  = "aztfmod/caf/azurerm"
+  #version = "~>5.4.2"
+
+  source = "git::https://github.com/weareplanet/terraform-azure-caf.git?ref=main"
+
+  providers = {
+    azurerm.vhub = azurerm.vhub
+  }
 
   azuread                     = local.azuread
   current_landingzone_key     = var.landingzone.key
+  database                    = local.database
   tenant_id                   = var.tenant_id
   tfstates                    = local.tfstates
   tags                        = local.tags
@@ -29,10 +36,11 @@ module "caf" {
 
   # Pass the remote objects you need to connect to.
   remote_objects = {
-    keyvaults          = local.remote.keyvaults
-    managed_identities = local.remote.managed_identities
-    azuread_groups     = local.remote.azuread_groups
-    vnets              = local.remote.vnets
+    keyvaults                  = local.remote.keyvaults
+    managed_identities         = local.remote.managed_identities
+    azuread_groups             = local.remote.azuread_groups
+    vnets                      = local.remote.vnets
+    app_config                 = local.remote.app_config
+    container_registry         = local.remote.azure_container_registries
   }
 }
-

--- a/caf_solution/add-ons/gha_runner/variables.tf
+++ b/caf_solution/add-ons/gha_runner/variables.tf
@@ -104,4 +104,9 @@ variable "dynamic_keyvault_secrets" {
 variable "managed_identities" {
   default = {}
 }
-
+variable "database" {
+  default = {}
+}
+variable "app_config_entries" {
+  default = {}
+}

--- a/caf_solution/local.database.tf
+++ b/caf_solution/local.database.tf
@@ -3,6 +3,7 @@ locals {
     var.database,
     {
       app_config                         = var.app_config
+      app_config_entries                 = var.app_config_entries
       azurerm_redis_caches               = var.azurerm_redis_caches
       cosmos_dbs                         = var.cosmos_dbs
       cosmosdb_sql_databases             = var.cosmosdb_sql_databases

--- a/caf_solution/variables.database.tf
+++ b/caf_solution/variables.database.tf
@@ -1,6 +1,10 @@
 variable "app_config" {
   default = {}
 }
+variable "app_config_entries" {
+  description = "Map of objects describing kv entries to an app config."
+  default     = {}
+}
 variable "azurerm_redis_caches" {
   default = {}
 }


### PR DESCRIPTION
Add appconfig functionality to gha_runner

Add the various hooks to allow passing app_config_entries over to the
CAF module from our gha_runner addon.

The use case is to allow us to create our appconfig settings (previously
variable groups) while setting up the runners. The alternative would be
to have a separate landingzone to add the entries but I'm trying to keep
the number of lzs down where possible.
