### PR TITLE
Continue if runners fail to remove

### DIFF
--- a/caf_solution/add-ons/gha_runner/extensions/gha_runner.tf
+++ b/caf_solution/add-ons/gha_runner/extensions/gha_runner.tf
@@ -43,23 +43,24 @@ resource "null_resource" "remove_runner" {
   }
 
   provisioner "local-exec" {
-    when    = destroy
-    command = "go run remove_runner.go"
+    when        = destroy
+    on_failure  = continue
+    command     = "go run remove_runner.go"
     working_dir = "scripts/remove_runner"
     environment = {
       GH_RUNNER_PREFIX = self.triggers.GH_RUNNER_PREFIX
-      GH_ORG = self.triggers.GH_ORG
-      GH_TOKEN = self.triggers.GH_TOKEN
-      GH_NUM_RUNNERS = self.triggers.GH_NUM_RUNNERS
+      GH_ORG           = self.triggers.GH_ORG
+      GH_TOKEN         = self.triggers.GH_TOKEN
+      GH_NUM_RUNNERS   = self.triggers.GH_NUM_RUNNERS
     }
   }
 
   # Triggers are used here due to limitations in Terraform on passing vars to local-exec/destroy
   triggers = {
     GH_RUNNER_PREFIX = join("-", concat(var.global_settings.prefixes, [var.settings[each.key].gha_runner.runner_name_prefix]))
-    GH_ORG = var.settings[each.key].gha_runner.gh_org
-    GH_TOKEN = var.settings[each.key].token
-    GH_NUM_RUNNERS = var.settings[each.key].gha_runner.num_runners
+    GH_ORG           = var.settings[each.key].gha_runner.gh_org
+    GH_TOKEN         = var.settings[each.key].token
+    GH_NUM_RUNNERS   = var.settings[each.key].gha_runner.num_runners
   }
 }
 

--- a/caf_solution/add-ons/gha_runner/solution.tf
+++ b/caf_solution/add-ons/gha_runner/solution.tf
@@ -36,11 +36,11 @@ module "caf" {
 
   # Pass the remote objects you need to connect to.
   remote_objects = {
-    keyvaults                  = local.remote.keyvaults
-    managed_identities         = local.remote.managed_identities
-    azuread_groups             = local.remote.azuread_groups
-    vnets                      = local.remote.vnets
-    app_config                 = local.remote.app_config
-    container_registry         = local.remote.azure_container_registries
+    keyvaults          = local.remote.keyvaults
+    managed_identities = local.remote.managed_identities
+    azuread_groups     = local.remote.azuread_groups
+    vnets              = local.remote.vnets
+    app_config         = local.remote.app_config
+    container_registry = local.remote.azure_container_registries
   }
 }


### PR DESCRIPTION
The null_resource workaround for unregistering deleted runners from
Github seems to work well, but occasionally can get out of sync with the
VM resources and try to remove runners that no longer exist. My hope is
this is mostly just a result of the churn that happens in a dev
environment, but when it happens it can make it difficult to go ahead
and destroy the module. Adding an on_failure condition to cover this.

Also fmt the module.