### PR TITLE
Add new module for configuring Github

### DIFF
--- a/caf_solution/add-ons/github/backend.azurerm
+++ b/caf_solution/add-ons/github/backend.azurerm
@@ -1,0 +1,4 @@
+terraform {
+    backend "azurerm" {
+    }
+}

--- a/caf_solution/add-ons/github/gha_secrets.tf
+++ b/caf_solution/add-ons/github/gha_secrets.tf
@@ -1,0 +1,45 @@
+resource "github_actions_secret" "secret" {
+  for_each = try(merge(local.static_secrets, local.dynamic_secrets), {})
+
+  repository      = each.value.repo_name
+  secret_name     = each.key
+  plaintext_value = each.value.secret_value
+}
+
+locals {
+  static_secrets = {
+    for setting in flatten(
+      [
+        for repo_name, repo_config in try(var.gh_repo_secrets, []) : [
+          for secret_key, secret_value in try(repo_config.static, []) : {
+            key = secret_key
+            value = {
+              secret_value = secret_value
+              repo_name    = repo_name
+            }
+          }
+        ]
+      ]
+    ) : setting.key => setting.value
+  }
+
+  dynamic_secrets = {
+    for setting in flatten(
+      [
+        for repo_name, repo_config in try(var.gh_repo_secrets, []) : [
+          for secret_key, secret_config in try(repo_config.dynamic, []) : [
+            for resource_type_key, resource in secret_config : [
+              for object_id_key, object_attributes in resource : {
+                key = secret_key
+                value = {
+                  secret_value = try(local.combined[resource_type_key][object_attributes.lz_key][object_id_key][object_attributes.attribute_key], local.combined[resource_type_key][var.landingzone.landingzone_key][object_id_key][object_attributes.attribute_key])
+                  repo_name    = repo_name
+                }
+              }
+            ]
+          ]
+        ]
+      ]
+    ) : setting.key => setting.value
+  }
+}

--- a/caf_solution/add-ons/github/locals.remote_tfstates.tf
+++ b/caf_solution/add-ons/github/locals.remote_tfstates.tf
@@ -1,0 +1,60 @@
+locals {
+  landingzone = {
+    current = {
+      storage_account_name = var.tfstate_storage_account_name
+      container_name       = var.tfstate_container_name
+      resource_group_name  = var.tfstate_resource_group_name
+    }
+    lower = {
+      storage_account_name = var.lower_storage_account_name
+      container_name       = var.lower_container_name
+      resource_group_name  = var.lower_resource_group_name
+    }
+  }
+}
+
+data "terraform_remote_state" "remote" {
+  for_each = try(var.landingzone.tfstates, {})
+
+  backend = var.landingzone.backend_type
+  config = {
+    storage_account_name = local.landingzone[try(each.value.level, "current")].storage_account_name
+    container_name       = local.landingzone[try(each.value.level, "current")].container_name
+    resource_group_name  = local.landingzone[try(each.value.level, "current")].resource_group_name
+    subscription_id      = var.tfstate_subscription_id
+    key                  = each.value.tfstate
+  }
+}
+
+locals {
+  landingzone_tag = {
+    "landingzone" = var.landingzone.key
+  }
+
+  tags = merge(local.global_settings.tags, local.landingzone_tag, { "level" = var.landingzone.level }, { "environment" = local.global_settings.environment }, { "rover_version" = var.rover_version }, var.tags)
+
+  global_settings = data.terraform_remote_state.remote[var.landingzone.global_settings_key].outputs.objects[var.landingzone.global_settings_key].global_settings
+  diagnostics     = data.terraform_remote_state.remote[var.landingzone.global_settings_key].outputs.objects[var.landingzone.global_settings_key].diagnostics
+
+  combined = {
+    keyvaults          = merge(local.remote.keyvaults, tomap({ (var.landingzone.key) = module.caf.keyvaults }))
+    managed_identities = merge(local.remote.managed_identities, tomap({ (var.landingzone.key) = module.caf.managed_identities }))
+    app_config         = merge(local.remote.app_config, tomap({ (var.landingzone.key) = module.caf.app_config }))
+  }
+
+  remote = {
+    keyvaults = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].keyvaults, {}))
+    }
+
+    managed_identities = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].managed_identities, {}))
+    }
+
+    app_config = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].app_config,
+      {}))
+    }
+  }
+}
+

--- a/caf_solution/add-ons/github/main.tf
+++ b/caf_solution/add-ons/github/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.2.1"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "github" {
+  token = data.azurerm_key_vault_secret.github_pat.value
+  owner = var.github.gh_org
+}
+
+provider "azurerm" {
+  partner_id = "ca4078f8-9bc4-471b-ab5b-3af6b86a42c8"
+  # partner identifier for CAF Terraform landing zones.
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = true
+    }
+  }
+}
+
+provider "azurerm" {
+  alias                      = "vhub"
+  skip_provider_registration = true
+  features {}
+}
+
+data "azurerm_key_vault_secret" "github_pat" {
+  name         = var.github.pat.secret_name
+  key_vault_id = try(var.github.pat.lz_key, null) == null ? local.combined.keyvaults[var.landingzone.key][var.github.pat.keyvault_key].id : local.combined.keyvaults[var.github.pat.lz_key][var.github.pat.keyvault_key].id
+}
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  # Update the tfstates map
+  tfstates = merge(
+    tomap(
+      {
+        (var.landingzone.key) = local.backend[var.landingzone.backend_type]
+      }
+    )
+    ,
+    data.terraform_remote_state.remote[var.landingzone.global_settings_key].outputs.tfstates
+  )
+
+  backend = {
+    azurerm = {
+      storage_account_name = var.tfstate_storage_account_name
+      container_name       = var.tfstate_container_name
+      resource_group_name  = var.tfstate_resource_group_name
+      key                  = var.tfstate_key
+      level                = var.landingzone.level
+      tenant_id            = var.tenant_id
+      subscription_id      = data.azurerm_client_config.current.subscription_id
+    }
+  }
+}

--- a/caf_solution/add-ons/github/output.tf
+++ b/caf_solution/add-ons/github/output.tf
@@ -1,0 +1,16 @@
+output "objects" {
+  value = tomap(
+    {
+      (var.landingzone.key) = {
+        for key, value in module.caf : key => value
+        if try(value, {}) != {}
+      }
+    }
+  )
+  sensitive = true
+}
+
+output "tfstates" {
+  value     = local.tfstates
+  sensitive = true
+}

--- a/caf_solution/add-ons/github/solution.tf
+++ b/caf_solution/add-ons/github/solution.tf
@@ -1,0 +1,16 @@
+module "caf" {
+  source = "git::https://github.com/weareplanet/terraform-azure-caf.git?ref=main"
+
+  providers = {
+    azurerm.vhub = azurerm.vhub
+  }
+
+  managed_identities = var.managed_identities
+  keyvaults          = var.keyvaults
+
+  remote_objects = {
+    keyvaults          = local.remote.keyvaults
+    managed_identities = local.remote.managed_identities
+    app_config         = local.remote.app_config
+  }
+}

--- a/caf_solution/add-ons/github/variables.tf
+++ b/caf_solution/add-ons/github/variables.tf
@@ -1,0 +1,34 @@
+# Map of the remote data state for lower level
+variable "lower_storage_account_name" {}
+variable "lower_container_name" {}
+variable "lower_resource_group_name" {}
+
+variable "tfstate_storage_account_name" {}
+variable "tfstate_container_name" {}
+variable "tfstate_key" {}
+variable "tfstate_resource_group_name" {}
+
+variable "tenant_id" {}
+variable "landingzone" {}
+variable "tfstate_subscription_id" {}
+variable "global_settings" {
+  default = {}
+}
+variable "rover_version" {
+  default = null
+}
+variable "tags" {
+  default = null
+}
+
+variable "managed_identities" {
+  default = {}
+}
+variable "keyvaults" {
+  default = {}
+}
+
+variable "github" {}
+variable "gh_repo_secrets" {
+  default = {}
+}


### PR DESCRIPTION
Uses the terraform github provider to configure various aspects of a
Github account/org.

Currently just supports setting secrets for Github actions, more
functionality can be added as required.

Sample tfvars:

```
{
    "github": {
        "gh_org": "PaulTestOrg3005",
        "pat": {
            "keyvault_key": "secrets",
            "lz_key": "launchpad",
            "secret_name": "github-pat"
        }
    },
    "gh_repo_secrets": {
        "my-repo": {                            // repo name
            "static": {
                "hello": "world"
            },

            "dynamic": {
                "level0_msi_resource_id": {     // secret name
                    "managed_identities": {     // object type
                        "level0": {             // object key
                            "attribute_key": "id",
                            "lz_key": "launchpad"
                        }
                    }
                }
            }
        }
    }
}
```
