### PR TITLE
Update github module to allow for environments

### DIFF
--- a/caf_solution/add-ons/gha_runner/main.tf
+++ b/caf_solution/add-ons/gha_runner/main.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "aztfmod/azurecaf"
       version = "~> 1.2.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 2.2.1"
-    }
     null = {
       source = "hashicorp/null"
     }

--- a/caf_solution/add-ons/github/gha_environments.tf
+++ b/caf_solution/add-ons/github/gha_environments.tf
@@ -1,0 +1,58 @@
+data "github_user" "users" {
+  for_each = local.users
+
+  username = each.key
+}
+
+data "github_team" "teams" {
+  for_each = local.teams
+
+  slug = each.key
+}
+
+resource "github_repository_environment" "env" {
+  for_each = local.environments
+
+  repository   = each.value.repo
+  environment  = each.value.env
+  reviewers {
+    users = [for i in try(each.value.reviewers.users, []): data.github_user.users[i].id]
+    teams = [for i in try(each.value.reviewers.teams, []): data.github_team.teams[i].id]
+  }
+}
+
+locals {
+  teams = toset(
+    flatten([
+      for repo, repo_settings in var.gh_environments : [
+        for env, env_settings in repo_settings : [
+          try(env_settings.reviewers.teams, [])
+        ]
+      ]
+    ])
+  )
+
+  users = toset(
+    flatten([
+      for repo, repo_settings in var.gh_environments : [
+        for env, env_settings in repo_settings : [
+          try(env_settings.reviewers.users, [])
+        ]
+      ]
+    ])
+  )
+
+  environments = {
+    for item in flatten([
+      for repo, repo_settings in var.gh_environments: [
+        for env, env_settings in repo_settings: {
+          value = {
+            env = env
+            reviewers = env_settings.reviewers
+            repo = repo
+          }
+        }
+      ]
+    ]) : format("%s-%s", item.value.repo, item.value.env) => item.value
+  }
+}

--- a/caf_solution/add-ons/github/gha_secrets.tf
+++ b/caf_solution/add-ons/github/gha_secrets.tf
@@ -1,45 +1,97 @@
-resource "github_actions_secret" "secret" {
-  for_each = try(merge(local.static_secrets, local.dynamic_secrets), {})
+data "azurerm_key_vault_secret" "secret" {
+  for_each = { for key, value in try(local.keyvault_secrets, {}) : key => value }
+
+  name         = each.value.secret_name
+  key_vault_id = try(each.value.lz_key, null) == null ? local.combined.keyvaults[var.landingzone.key][each.value.keyvault_key].id : local.combined.keyvaults[each.value.lz_key][each.value.keyvault_key].id
+}
+
+resource "github_actions_secret" "dynamic_secret" {
+  for_each = {
+    for key, value in try(local.dynamic_secrets, {}) : key => value
+    if try(value.environment, null) == null
+  }
 
   repository      = each.value.repo_name
-  secret_name     = each.key
+  secret_name     = each.value.secret_key
   plaintext_value = each.value.secret_value
 }
 
-locals {
-  static_secrets = {
-    for setting in flatten(
-      [
-        for repo_name, repo_config in try(var.gh_repo_secrets, []) : [
-          for secret_key, secret_value in try(repo_config.static, []) : {
-            key = secret_key
-            value = {
-              secret_value = secret_value
-              repo_name    = repo_name
-            }
-          }
-        ]
-      ]
-    ) : setting.key => setting.value
+resource "github_actions_environment_secret" "dynamic_env_secret" {
+  for_each = {
+    for key, value in try(local.dynamic_secrets, {}) : key => value
+    if try(value.environment, null) != null
+  }
+  depends_on = [github_repository_environment.env]
+
+  repository      = each.value.repo_name
+  environment     = each.value.environment
+  secret_name     = each.value.secret_key
+  plaintext_value = each.value.secret_value
+}
+
+resource "github_actions_secret" "keyvault_secret" {
+  for_each = {
+    for key, value in try(local.keyvault_secrets, {}) : key => value
+    if try(value.environment, null) == null
   }
 
+  repository      = each.value.repo_name
+  secret_name     = each.value.secret_key
+  plaintext_value = data.azurerm_key_vault_secret.secret[each.key].value
+}
+
+resource "github_actions_environment_secret" "keyvault_env_secret" {
+  for_each = {
+    for key, value in try(local.keyvault_secrets, {}) : key => value
+    if try(value.environment, null) != null
+  }
+  depends_on = [github_repository_environment.env]
+
+  repository      = each.value.repo_name
+  environment     = each.value.environment
+  secret_name     = each.value.secret_key
+  plaintext_value = data.azurerm_key_vault_secret.secret[each.key].value
+}
+
+locals {
   dynamic_secrets = {
-    for setting in flatten(
-      [
-        for repo_name, repo_config in try(var.gh_repo_secrets, []) : [
-          for secret_key, secret_config in try(repo_config.dynamic, []) : [
+    for secret in flatten([
+      for repo_name, repo_config in try(var.gh_repo_secrets, {}) : [
+        for secret in try(repo_config.dynamic, []) : [
+          for secret_key, secret_config in secret : [
             for resource_type_key, resource in secret_config : [
               for object_id_key, object_attributes in resource : {
-                key = secret_key
                 value = {
+                  secret_key   = secret_key
                   secret_value = try(local.combined[resource_type_key][object_attributes.lz_key][object_id_key][object_attributes.attribute_key], local.combined[resource_type_key][var.landingzone.landingzone_key][object_id_key][object_attributes.attribute_key])
                   repo_name    = repo_name
+                  environment  = try(object_attributes.environment, null)
                 }
               }
             ]
           ]
         ]
       ]
-    ) : setting.key => setting.value
+      ]
+    ) : format("%s-%s", secret.value.secret_key, try(secret.value.environment, "")) => secret.value
+  }
+
+  keyvault_secrets = {
+    for secret in flatten([
+      for repo_name, repo_config in try(var.gh_repo_secrets, {}) : [
+        for secret in try(repo_config.keyvault, []) : [
+          for secret_key, secret_config in secret : {
+            value = {
+              secret_key   = secret_key
+              secret_name  = secret_config.name
+              keyvault_key = secret_config.key
+              lz_key       = secret_config.lz_key
+              environment  = try(secret_config.environment, null)
+              repo_name    = repo_name
+            }
+          }
+        ]
+      ]
+    ]) : format("%s-%s", secret.value.secret_key, try(secret.value.environment, "")) => secret.value
   }
 }

--- a/caf_solution/add-ons/github/main.tf
+++ b/caf_solution/add-ons/github/main.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "integrations/github"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 2.2.1"
-    }
   }
   required_version = ">= 0.13"
 }

--- a/caf_solution/add-ons/github/variables.tf
+++ b/caf_solution/add-ons/github/variables.tf
@@ -32,3 +32,6 @@ variable "github" {}
 variable "gh_repo_secrets" {
   default = {}
 }
+variable "gh_environments" {
+  default = {}
+}


### PR DESCRIPTION
Introduces a new var `gha_environments`:

```
{
   "gh_environments": {
      "repo1": {
         "env1": {
            "reviewers": {
               "teams": [
                  "team1"
               ],
               "users": [
                  "user1"
               ]
            }
         }
      }
   }
}
```

For more about Github environments, see
https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment

Also:
* Update the gha_secrets functionality to allow for environments (you
  can now optionally set secrets per environment).

* Add support for keyvault secrets

* Remove dependency on random from this and gha_runner, no longer
  required with latest upstream.
