### PR TITLE
Add missing caf vars to github module

### DIFF
--- a/caf_solution/add-ons/github/solution.tf
+++ b/caf_solution/add-ons/github/solution.tf
@@ -5,8 +5,10 @@ module "caf" {
     azurerm.vhub = azurerm.vhub
   }
 
-  managed_identities = var.managed_identities
-  keyvaults          = var.keyvaults
+  logged_user_objectId                  = var.logged_user_objectId
+  logged_aad_app_objectId               = var.logged_aad_app_objectId
+  managed_identities                    = var.managed_identities
+  keyvaults                             = var.keyvaults
 
   remote_objects = {
     keyvaults          = local.remote.keyvaults

--- a/caf_solution/add-ons/github/variables.tf
+++ b/caf_solution/add-ons/github/variables.tf
@@ -20,6 +20,12 @@ variable "rover_version" {
 variable "tags" {
   default = null
 }
+variable "logged_user_objectId" {
+  default = null
+}
+variable "logged_aad_app_objectId" {
+  default = null
+}
 
 variable "managed_identities" {
   default = {}


### PR DESCRIPTION
When running plan/apply in a workflow Rover will set these which are
required by some parts of the CAF module.
