### PR TITLE
Allow GHA runners to be repo scoped

### DIFF
--- a/caf_solution/add-ons/gha_runner/scripts/gha_runner_runtime_baremetal.sh
+++ b/caf_solution/add-ons/gha_runner/scripts/gha_runner_runtime_baremetal.sh
@@ -2,16 +2,23 @@
 
 set -euxo pipefail
 
-GH_ORG=${1}
-TOKEN=${2}
-PREFIX=${3}
-ADMIN_USER=${4}
-NUM_RUNNERS=${5}
-LABELS=${6}
+REPO=${1} # if non empty, add runner at repo scope, else add to org
+GH_ORG=${2}
+TOKEN=${3}
+PREFIX=${4}
+ADMIN_USER=${5}
+NUM_RUNNERS=${6}
+LABELS=${7}
 
 LATEST_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep -oP '"tag_name": "v\K(.*)(?=")')
 RUNNER_URL="https://github.com/actions/runner/releases/download/v${LATEST_VERSION}/actions-runner-linux-x64-${LATEST_VERSION}.tar.gz"
-RUNNER_TOKEN_URL="https://api.github.com/orgs/${GH_ORG}/actions/runners/registration-token"
+if [[ ${REPO} == "" ]]; then
+  RUNNER_TOKEN_URL="https://api.github.com/orgs/${GH_ORG}/actions/runners/registration-token"
+  REGISTRATION_URL="https://github.com/${GH_ORG}"
+else
+  RUNNER_TOKEN_URL="https://api.github.com/repos/${GH_ORG}/${REPO}/actions/runners/registration-token"
+  REGISTRATION_URL="https://github.com/${GH_ORG}/${REPO}"
+fi
 
 export DEBIAN_FRONTEND=noninteractive
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
@@ -45,8 +52,8 @@ for i in $(seq 1 ${NUM_RUNNERS}); do
   RUNNER_TOKEN=$(curl -sS -X POST --url ${RUNNER_TOKEN_URL} -H "Authorization: Bearer ${TOKEN}" \
     -H 'Content-Type: application/json' | jq -r .token)
 
-  sudo -u ${ADMIN_USER} ./config.sh --unattended --url https://github.com/${GH_ORG} \
-    --token ${RUNNER_TOKEN} --replace --name ${runner_name} --labels ${LABELS}
+  sudo -u ${ADMIN_USER} ./config.sh --unattended --url ${REGISTRATION_URL} --token ${RUNNER_TOKEN} \
+    --replace --name ${runner_name} --labels ${LABELS}
   ./svc.sh install
   ./svc.sh start
 


### PR DESCRIPTION
You can now optionally add a 'repo' arg to your runner config to have it
scoped to that repo rather than the entire org:

```
gha_runner: {
  myrunner: {
    runner_name_prefix: "azure_infra"
    labels:             "azure_infra"
    num_runners:        4
    gh_org:             "myorg"
    repo:               "myrepo"
    pats: {
      runner: {
      keyvault_key: "secrets"
      lz_key:       "launchpad"
      secret_name:  "github-pat"
    }
  }
}
```
